### PR TITLE
add sort functionality on both inventory and warehouse lists

### DIFF
--- a/src/components/InventoryList/InventoryList.jsx
+++ b/src/components/InventoryList/InventoryList.jsx
@@ -9,15 +9,37 @@ function InventoryList({
   keyword,
   handleOpenInventoryModal,
 }) {
-  const [isSearch, setIsSearch] = useState(false);
+  const [items, setItems] = useState([]);
+  const [order, setOrder] = useState("asc");
+  const [column, setColumn] = useState("");
+
+  useEffect(() => {
+    sortItems();
+  }, [order, column]);
 
   useEffect(() => {
     if (keyword) {
-      setIsSearch(true);
+      setItems(results);
     } else {
-      setIsSearch(false);
+      setItems(inventories);
     }
-  }, [keyword]);
+  }, [keyword, results, inventories]);
+
+  const sortItems = () => {
+    const sortedItems = [...items].sort((a, b) => {
+      if (order === "asc") {
+        return a[column] > b[column] ? 1 : -1;
+      } else {
+        return a[column] < b[column] ? 1 : -1;
+      }
+    });
+    setItems(sortedItems);
+  };
+
+  const handleSort = (col) => {
+    setColumn(col);
+    setOrder(order === "asc" ? "desc" : "asc");
+  };
   return (
     <div>
       <section className="inventory-list-section">
@@ -27,6 +49,7 @@ function InventoryList({
             <img
               src={SortIcon}
               alt="Sort"
+              onClick={() => handleSort("item_name")}
               className="inventory-list-section__label-img"
             />
           </div>
@@ -35,6 +58,7 @@ function InventoryList({
             <img
               src={SortIcon}
               alt="Sort"
+              onClick={() => handleSort("category")}
               className="inventory-list-section__label-img"
             />
           </div>
@@ -43,6 +67,7 @@ function InventoryList({
             <img
               src={SortIcon}
               alt="Sort"
+              onClick={() => handleSort("status")}
               className="inventory-list-section__label-img"
             />
           </div>
@@ -51,6 +76,7 @@ function InventoryList({
             <img
               src={SortIcon}
               alt="Sort"
+              onClick={() => handleSort("quantity")}
               className="inventory-list-section__label-img"
             />
           </div>
@@ -61,6 +87,7 @@ function InventoryList({
             <img
               src={SortIcon}
               alt="Sort"
+              onClick={() => handleSort("warehouse_name")}
               className="inventory-list-section__label-img"
             />
           </div>
@@ -69,7 +96,7 @@ function InventoryList({
           </div>
         </div>
         <ul className="inventory-list">
-          {(isSearch ? results : inventories).map((item) => (
+          {items.map((item) => (
             <InventoryItem
               key={item.id}
               inventory={item}

--- a/src/components/WarehouseList/WarehouseList.jsx
+++ b/src/components/WarehouseList/WarehouseList.jsx
@@ -2,23 +2,44 @@ import WarehouseItem from "../WarehouseItem/WarehouseItem";
 import SortIcon from "../../assets/Icons/sort-24px.svg";
 import "./WarehouseList.scss";
 import { useEffect, useState } from "react";
-
+import axios from "axios";
 function WarehouseList({
   warehouses,
   results,
   handleOpenWarehouseModal,
   keyword,
 }) {
-  const [isSearch, setIsSearch] = useState(false);
+  const [items, setItems] = useState([]);
+  const [order, setOrder] = useState("asc");
+  const [column, setColumn] = useState("");
+
+  useEffect(() => {
+    sortItems();
+  }, [order, column]);
 
   useEffect(() => {
     if (keyword) {
-      setIsSearch(true);
+      setItems(results);
     } else {
-      setIsSearch(false);
+      setItems(warehouses);
     }
-  }, [keyword]);
+  }, [keyword, results, warehouses]);
 
+  const sortItems = () => {
+    const sortedItems = [...items].sort((a, b) => {
+      if (order === "asc") {
+        return a[column] > b[column] ? 1 : -1;
+      } else {
+        return a[column] < b[column] ? 1 : -1;
+      }
+    });
+    setItems(sortedItems);
+  };
+
+  const handleSort = (col) => {
+    setColumn(col);
+    setOrder(order === "asc" ? "desc" : "asc");
+  };
   return (
     <>
       <section className="warehouse-list-section">
@@ -28,6 +49,7 @@ function WarehouseList({
             <img
               src={SortIcon}
               alt="Sort"
+              onClick={() => handleSort("warehouse_name")}
               className="warehouse-list-section__label-img"
             />
           </div>
@@ -36,6 +58,7 @@ function WarehouseList({
             <img
               src={SortIcon}
               alt="Sort"
+              onClick={() => handleSort("address")}
               className="warehouse-list-section__label-img"
             />
           </div>
@@ -45,6 +68,7 @@ function WarehouseList({
             <img
               src={SortIcon}
               alt="Sort"
+              onClick={() => handleSort("contact_name")}
               className="warehouse-list-section__label-img"
             />
           </div>
@@ -55,6 +79,7 @@ function WarehouseList({
             <img
               src={SortIcon}
               alt="Sort"
+              onClick={() => handleSort("contact_email" || "contact_phone")}
               className="warehouse-list-section__label-img"
             />
           </div>
@@ -63,7 +88,7 @@ function WarehouseList({
           </div>
         </div>
         <ul className="warehouse-list">
-          {(isSearch ? results : warehouses).map((item) => (
+          {items.map((item) => (
             <WarehouseItem
               key={item.id}
               warehouse={item}


### PR DESCRIPTION
Add sort functionality on both frontend  inventory and warehouse lists. I tried using the backend route for sorting it actually worked  but was getting long as I had to write lots of use Effects and after passing search query and trying to sort the resultant data It was resetting to fetching all data instead of persisting the filtered data as per search query.  So I found implementing on frontend was easier for me. 