### PR TITLE
Feat/general styles

### DIFF
--- a/src/components/AddNewWarehouse/AddNewWarehouse.scss
+++ b/src/components/AddNewWarehouse/AddNewWarehouse.scss
@@ -14,7 +14,7 @@
         align-items: center;
         background-color: #ffffff;
         width: 100%;
-        height: 9rem;
+        height: 9.7rem;
         border-bottom: solid #BDC5D5;
         border-width: 0.1rem;
         padding: 2rem;

--- a/src/components/ContentWrapper/ContentWrapper.scss
+++ b/src/components/ContentWrapper/ContentWrapper.scss
@@ -8,11 +8,12 @@
 	background-color: #ffffff;
 	border-radius: 4px;
 	box-shadow: 0px 2px 5px #13182c34;
-	transform: translateY(-3.4rem);
+	transform: translateY(-5.8rem);
+	overflow: hidden;
 
 	@include tablet {
 		margin: 0 32px;
-		transform: translateY(-6rem);
+		transform: translateY(-9.7rem);
 	}
 	@include desktop {
 		width: 1020px;

--- a/src/components/EditWarehouseItem/EditWarehouseItem.scss
+++ b/src/components/EditWarehouseItem/EditWarehouseItem.scss
@@ -14,7 +14,7 @@
         align-items: center;
         background-color: #ffffff;
         width: 100%;
-        height: 9rem;
+        height: 9.7rem;
         border-bottom: solid #BDC5D5;
         border-width: 0.1rem;
         padding: 2rem;

--- a/src/components/Header/Header.scss
+++ b/src/components/Header/Header.scss
@@ -9,7 +9,7 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    height: 17rem;
+    height: 19.5rem;
     @include labels-links-buttons;
     @include tablet {
         flex-direction: row;

--- a/src/pages/InventoryDetailsPage/InventoryDetailsPage.jsx
+++ b/src/pages/InventoryDetailsPage/InventoryDetailsPage.jsx
@@ -46,7 +46,6 @@ function InventoryDetailsPage () {
                     </button>
                 </Link>
             </div>
-            <hr />
             <InventoryItemDetails details={inventoryDetails} />
         </section>
         </>

--- a/src/styles/partials/_global.scss
+++ b/src/styles/partials/_global.scss
@@ -23,6 +23,8 @@ time, img, button {
 
 body {
     font-family: 'Titillium Web', Arial, Helvetica, sans-serif;
+    background-color: $color-lightgrey;
+    color: $color-is-black;
 }
 
 button, input, textarea {

--- a/src/styles/partials/_mixins.scss
+++ b/src/styles/partials/_mixins.scss
@@ -15,7 +15,6 @@
 @mixin page-header {
   font-size: 2.8rem;
   line-height: 3.6rem;
-  color: $color-is-black;
 
   @include tablet {
     font-size: 3.2rem;
@@ -26,7 +25,6 @@
 @mixin subheader {
   font-size: 2rem;
   line-height: 2.8rem;
-  color: $color-is-black;
 
   @include tablet {
     font-size: 2.4rem;
@@ -60,7 +58,6 @@
 @mixin body-large {
   font-size: 1.5rem;
   line-height: 2.6rem;
-  color: $color-is-black;
 
   @include tablet {
     font-size: 1.6rem;
@@ -71,7 +68,6 @@
 @mixin body-medium {
   font-size: 1.3rem;
   line-height: 2rem;
-  color: $color-is-black;
 
   @include tablet {
     font-size: 1.4rem;
@@ -82,7 +78,6 @@
 @mixin body-small {
   font-size: 1.1rem;
   line-height: 1.6rem;
-  color: $color-is-black;
 
   @include tablet {
     font-size: 1.2rem;


### PR DESCRIPTION
Fix site background to be lightgrey instead of white, remove default text colors in mixin to prevent overriding specific text colors, realign headers with top background color, and make border radius consistently appear for all pages.