### PR TITLE
Fix: Components within warehouse list page

### DIFF
--- a/src/components/WarehouseItem/WarehouseItem.scss
+++ b/src/components/WarehouseItem/WarehouseItem.scss
@@ -11,6 +11,10 @@
     padding: 2.4rem;
     gap: 1.6rem;
     @include body-medium;
+    
+    &:nth-last-child(1) {
+      border-bottom: none;
+    }
 
     &:hover {
       background-color: #2E66E512;
@@ -136,6 +140,10 @@
     &__chevron{
       height: 2rem;
       @include chevron-transition;
+
+      @include tablet {
+        margin-left: 0.5rem;
+      }
     }
   
     &__actions-container {

--- a/src/components/WarehouseList/WarehouseList.scss
+++ b/src/components/WarehouseList/WarehouseList.scss
@@ -62,6 +62,7 @@
           @include tablet {
             justify-content: end;
             flex: 0 0 8%;
+            padding-right: 0;
           }
         }
 			}
@@ -73,6 +74,7 @@
     @include tablet {
       background: none;
       padding: 0;
+      margin-left: 0.35rem;
       vertical-align: middle; 
       width: 1.6rem;
       height: 1.6rem;


### PR DESCRIPTION
Move actions label to the right, add space between label and sort icon, add space between inventory name and chevron, remove border from the bottom-most warehouse item
