### PR TITLE
Fix: Components within inventory list page

### DIFF
--- a/src/components/InventoryItem/InventoryItem.scss
+++ b/src/components/InventoryItem/InventoryItem.scss
@@ -10,6 +10,10 @@
     color: $color-is-black;
     padding: 2.4rem;
 
+    &:nth-last-child(1) {
+      border-bottom: none;
+    }
+
     &:hover {
       background-color: #2E66E512;
     }
@@ -134,6 +138,10 @@
     &__chevron{
       height: 2rem;
       @include chevron-transition;
+
+      @include tablet {
+        margin-left: 0.5rem;
+      }
     }
   
     &__status {
@@ -143,7 +151,6 @@
       align-items: center;
       text-transform: uppercase;
       white-space: nowrap;
-      cursor: pointer;
       padding: 0.4rem 0.8rem; 
       line-height: 2rem;
       font-size: 1.1rem;

--- a/src/components/InventoryList/InventoryList.scss
+++ b/src/components/InventoryList/InventoryList.scss
@@ -80,6 +80,7 @@
   &-img {
     @include tablet {
       background: none;
+      margin-left: 0.35rem;
       padding: 0;
       vertical-align: middle; 
       width: 1.6rem;


### PR DESCRIPTION
Add space between label and sort icon, add space between item name and chevron, stock status no longer clickable, and remove border-bottom only from last inventory item