### PR TITLE
Fix: Components within warehouse-specific inventory page

### DIFF
--- a/src/components/WarehouseInventory/WarehouseInventory.jsx
+++ b/src/components/WarehouseInventory/WarehouseInventory.jsx
@@ -75,13 +75,16 @@ function WarehouseInventory({ inventory, handleOpenInventoryModal }) {
         </div>
       </div>
       <ul className="warehouse-inventory__items">
-        {items.map((item) => (
-          <WarehouseInventoryItem
-            key={item.id}
-            item={item}
-            handleOpenInventoryModal={handleOpenInventoryModal}
-          />
-        ))}
+        {
+        items.length === 0 ? <li className="warehouse-inventory__none">There are no inventories at this warehouse.</li> :
+            items.map((item) => (
+                <WarehouseInventoryItem
+                  key={item.id}
+                  item={item}
+                  handleOpenInventoryModal={handleOpenInventoryModal}
+                />
+            ))
+        }
       </ul>
     </section>
   );

--- a/src/components/WarehouseInventory/WarehouseInventory.scss
+++ b/src/components/WarehouseInventory/WarehouseInventory.scss
@@ -74,7 +74,7 @@
         @include tablet {
             background: none;
             padding: 0;
-            margin-left: 0.2rem;
+            margin-left: 0.35rem;
             vertical-align: middle;
             width: 1.6rem;
             height: 1.6rem;
@@ -84,5 +84,13 @@
     &__items {
         padding: 0;
         margin: 0;
+    }
+
+    &__none {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        height: 4rem;
+        @include body-medium;
     }
 }

--- a/src/components/WarehouseInventoryItem/WarehouseInventoryItem.scss
+++ b/src/components/WarehouseInventoryItem/WarehouseInventoryItem.scss
@@ -10,6 +10,10 @@
     color: $color-is-black;
     padding: 2.4rem;
 
+    &:nth-last-child(1) {
+        border-bottom: none;
+    }
+
     &:hover {
         background-color: #2E66E512;
     }
@@ -135,7 +139,7 @@
 
     &__chevron {
         height: 2rem;
-        margin-left: 0.25rem;
+        margin-left: 0.5rem;
         @include chevron-transition;
     }
 
@@ -146,7 +150,6 @@
         align-items: center;
         text-transform: uppercase;
         white-space: nowrap;
-        cursor: pointer;
         padding: 0.4rem 0.8rem;
         line-height: 2rem;
         font-size: 1.1rem;


### PR DESCRIPTION
In terms of styling, this adds space between label and sort icon, adds space between inventory item and chevron, removes bottom-border only from the very last inventory item, and stock status is no longer clickable. In terms of functionality, message "There are no inventories at this warehouse." appears when a warehouse does not have any inventory to list.